### PR TITLE
Text lists classes

### DIFF
--- a/lib/classes/Utils.js
+++ b/lib/classes/Utils.js
@@ -87,5 +87,17 @@ module.exports = {
 			result.unshift(`${days}d`);
 
 		return result.join(" ");
+	},
+
+	/**
+	 * Escape special markdown symbol "`" and wrapping this string into code block (with single quote).
+	 * @param {string} value Original string.
+	 * @return {string} Escaped string. If after escaping this string will empty then it returns empty string.
+	 */
+	escapeMarkdown(value) {
+		let escaped = value.replaceAll("`", "");
+		if (escaped.length === 0)
+			return "";
+		return `\`${escaped}\``;
 	}
 };

--- a/lib/classes/content/BulletedList.js
+++ b/lib/classes/content/BulletedList.js
@@ -1,4 +1,12 @@
+const { log } = require("../Utils");
+
 class BulletedList extends Array {
+	/**
+	 * Array of allowed marker types.
+	 * @type {string[]}
+	 */
+	static #allowedMarkerTypes = ["string", "number"];
+
 	/**
 	 * List marker.
 	 * @type {string}
@@ -6,11 +14,19 @@ class BulletedList extends Array {
 	#marker = "+";
 
 	/**
-	 * @param {string} value New marker value.
+	 * @param {string|number} value New marker value.
 	 */
 	set marker(value) {
-		if (typeof value === "string" && value.length > 0)
+		if (this.constructor.#allowedMarkerTypes.includes(typeof value)) {
+			value = value.toString();
+			// If empty string passed then reset marker to default
+			if (value.length < 1)
+				value = "+";
 			this.#marker = value;
+		} else {
+			log("warn", "");
+			console.trace();
+		}
 	}
 
 	get marker() {

--- a/lib/classes/content/BulletedList.js
+++ b/lib/classes/content/BulletedList.js
@@ -1,0 +1,35 @@
+class BulletedList extends Array {
+	/**
+	 * List marker.
+	 * @type {string}
+	 */
+	#marker = "+";
+
+	/**
+	 * @param {string} value New marker value.
+	 */
+	set marker(value) {
+		if (typeof value === "string" && value.length > 0)
+			this.#marker = value;
+	}
+
+	get marker() {
+		return this.#marker;
+	}
+
+	/**
+	 * Generate text from this array.
+	 * @return {string} Generated content.
+	 */
+	toString() {
+		let tempResult = [];
+		this.forEach(value => {
+			tempResult.push(
+				this.#marker + " " + value
+			);
+		});
+		return tempResult.join("\n");
+	}
+}
+
+module.exports = BulletedList;

--- a/lib/classes/content/BulletedList.js
+++ b/lib/classes/content/BulletedList.js
@@ -14,18 +14,21 @@ class BulletedList extends Array {
 	#marker = "+";
 
 	/**
-	 * @param {string|number} value New marker value.
+	 * @param {string|number|null} value New marker value.
 	 */
 	set marker(value) {
+		// Setting up default value on null passed.
+		if (value === null)
+			value = "+";
 		if (this.constructor.#allowedMarkerTypes.includes(typeof value)) {
 			value = value.toString();
-			// If empty string passed then reset marker to default
+			// If empty string passed then reset marker to default.
 			if (value.length < 1)
 				value = "+";
 			this.#marker = value;
 		} else {
-			log("warn", "");
-			console.trace();
+			log("warn", `Trying to pass wrong marker type on !${this.name}`);
+			console.trace("Warning: Incorrect marker type passed at:");
 		}
 	}
 

--- a/lib/classes/content/BulletedList.js
+++ b/lib/classes/content/BulletedList.js
@@ -1,5 +1,3 @@
-const { log } = require("../Utils");
-
 class BulletedList extends Array {
 	/**
 	 * Array of allowed marker types.
@@ -27,8 +25,7 @@ class BulletedList extends Array {
 				value = "+";
 			this.#marker = value;
 		} else {
-			log("warn", `Trying to pass wrong marker type on !${this.name}`);
-			console.trace("Warning: Incorrect marker type passed at:");
+			console.trace(`Warning: Incorrect marker type passed to ${this.name} object at:`);
 		}
 	}
 

--- a/lib/classes/content/OrderedList.js
+++ b/lib/classes/content/OrderedList.js
@@ -15,8 +15,11 @@ class OrderedList extends Array {
 	 * @param {number} value Starting point.
 	 */
 	set startPoint(value) {
-		if (typeof value === "number" && isFinite(value))
+		if (typeof value === "number" && isFinite(value) && value > 0)
 			this.#startPoint = value;
+		else {
+			console.trace(`Warning: Incorrect starting point passed to ${this.name} object at:`);
+		}
 	}
 
 	/**

--- a/lib/classes/content/OrderedList.js
+++ b/lib/classes/content/OrderedList.js
@@ -1,0 +1,39 @@
+const { escapeMarkdown } = require("../Utils.js");
+
+class OrderedList extends Array {
+	/**
+	 * Starting point of ordered list.
+	 * @type {number}
+	 */
+	#startPoint = 1;
+
+	get startPoint() {
+		return this.#startPoint;
+	}
+
+	/**
+	 * @param {number} value Starting point.
+	 */
+	set startPoint(value) {
+		if (typeof value === "number" && isFinite(value))
+			this.#startPoint = value;
+	}
+
+	/**
+	 * Generate text from this array.
+	 * @return {string}
+	 */
+	toString() {
+		let tempResult = [];
+		this.forEach((value, index) => {
+			tempResult.push(
+				escapeMarkdown(
+					(index + this.#startPoint).toString()
+				) + " " + value
+			);
+		});
+		return tempResult.join("\n");
+	}
+}
+
+module.exports = OrderedList;

--- a/lib/commands/basic/AboutCommand.js
+++ b/lib/commands/basic/AboutCommand.js
@@ -4,14 +4,7 @@ const CoreCategory = require("../../categories/CoreCategory");
 
 class AboutCommand extends BaseCommand {
 	async run() {
-		const clientUser = this.message.client.user;
-		return new DefaultEmbed(this.message, "guild")
-			.setThumbnail(
-				clientUser.avatarURL({
-					format: "png",
-					size: 4096
-				})
-			)
+		return new DefaultEmbed(this.message, "self")
 			.setTitle(
 				this.resolveLang("bot.name")
 			)

--- a/lib/commands/basic/AboutCommand.js
+++ b/lib/commands/basic/AboutCommand.js
@@ -12,11 +12,15 @@ class AboutCommand extends BaseCommand {
 					size: 4096
 				})
 			)
-			.setTitle("bot.name")
-			.setDescription("bot.description")
+			.setTitle(
+				this.resolveLang("bot.name")
+			)
+			.setDescription(
+				this.resolveLang("bot.description")
+			)
 			.addField(
-				"command.about.links.title",
-				"command.about.links.description"
+				this.resolveLang("command.about.links.title"),
+				this.resolveLang("command.about.links.description")
 			);
 	}
 


### PR DESCRIPTION
Closes #1 — `DefaultEmbed` must be used instead. Generating text using 
Partially implemented #2 — Two classes for generating bulleted and ordered lists.

`OrderedList` usage:

```js
let list = new OrderedList();
list.startingPoint = 1;
list.push("Item");
list.push("Another item");
list.toString();
// `1.` Item\n
// `2.` Another item
```

`BulletedList` usage similar with `OrderedList` (both classes extends default `Array`), but there is no starting point. To set different marker, just change `BulletedList.marker`.

```js
let list = new BulletedList();
list.marker = "-";
// etc...
```