### PR TITLE
Using dev dbtype for development purposes instead of sqlite

### DIFF
--- a/config/.default/db.json
+++ b/config/.default/db.json
@@ -1,10 +1,4 @@
 {
   "$schema": "https://files.thecore.city/schemas/cognitum/db.schema.json",
-  "dbtype": "mariadb",
-  "mariadb": {
-    "host": "localhost",
-    "database": "cognitum",
-    "username": "root",
-    "password": "root"
-  }
+  "dbtype": "dev"
 }

--- a/lib/classes/Database.js
+++ b/lib/classes/Database.js
@@ -59,6 +59,7 @@ class Database {
 	static #dbInstance = {
 		dev() {
 			return new Sequelize("cognitum_dev", "cognitum_dev", "cognitum_dev", {
+				logging: Config.get("preferences.cognitum.debug"),
 				host: "localhost",
 				dialect: "mariadb",
 				dialectOptions: {
@@ -71,6 +72,7 @@ class Database {
 			let db = Config.get("db.mariadb");
 			let pool = Config.get("db.pool");
 			return new Sequelize(db.database, db.username, db.password, {
+				logging: Config.get("preferences.cognitum.debug"),
 				host: db.host,
 				dialect: "mariadb",
 				dialectOptions: {

--- a/lib/classes/Database.js
+++ b/lib/classes/Database.js
@@ -57,8 +57,14 @@ class Database {
 	};
 
 	static #dbInstance = {
-		inmemory() {
-			return new Sequelize("sqlite::memory:");
+		dev() {
+			return new Sequelize("cognitum_dev", "cognitum_dev", "cognitum_dev", {
+				host: "localhost",
+				dialect: "mariadb",
+				dialectOptions: {
+					timezone: process.env.TZ
+				}
+			});
 		},
 
 		mariadb() {

--- a/lib/schemas/db.schema.json
+++ b/lib/schemas/db.schema.json
@@ -9,12 +9,12 @@
     "dbtype": {
       "type": "string",
       "title": "Database type",
-      "description": "Choosing one of the available database types. \"inmemory\" option used for debugging only.",
+      "description": "Choosing one of the available database types. \"dev\" option used for development only.",
       "enum": [
-        "inmemory",
+        "dev",
         "mariadb"
       ],
-      "default": "inmemory"
+      "default": "dev"
     },
     "mariadb": {
       "type": "object",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "babel-eslint": "^10.1.0",
     "eslint": "^7.3.1",
     "readline-sync": "^1.4.10",
-    "sequelize-cli": "^6.2.0",
-    "sqlite3": "^5.0.0"
+    "sequelize-cli": "^6.2.0"
   }
 }


### PR DESCRIPTION
Added "dev" option for development using default login, password and database name.
Removed sqlite.