### PR TITLE
Statistics pushing on new message, module logging function and other improvements

### DIFF
--- a/lib/classes/CommandsRegistry.js
+++ b/lib/classes/CommandsRegistry.js
@@ -1,5 +1,6 @@
 const fs = require("fs").promises;
-const { log, fileExtension } = require("./Utils.js");
+const { fileExtension, createModuleLog } = require("./Utils.js");
+const log = createModuleLog("Commands");
 const BaseCommand = require("../commands/BaseCommand.js");
 const BaseCategory = require("../categories/BaseCategory.js");
 

--- a/lib/classes/ConfigManager.js
+++ b/lib/classes/ConfigManager.js
@@ -1,4 +1,5 @@
-const { log, fileName } = require("./Utils");
+const { createModuleLog, fileName } = require("./Utils");
+const log = createModuleLog("Config");
 const path = require("path");
 const fs = require("fs").promises;
 const _ = require("lodash");

--- a/lib/classes/ConfigManager.js
+++ b/lib/classes/ConfigManager.js
@@ -57,7 +57,6 @@ class ConfigManager {
 
 	/**
 	 * Get configuration value by path. It uses lodash `at` methods to resolve path.
-	 * @param {string} config Config object.
 	 * @param {string} path Path to config entry.
 	 * @return {null|string|any} Value from configuration values list. If value is not set then it returns null.
 	 */

--- a/lib/classes/Database.js
+++ b/lib/classes/Database.js
@@ -7,7 +7,8 @@ const MessageStatistics = require("../database/models/MessageStatistics.js");
 const User = require("../database/models/User.js");
 const VoiceStatistics = require("../database/models/VoiceStatistics.js");
 
-const { log } = require("../classes/Utils.js");
+const { createModuleLog } = require("../classes/Utils.js");
+const log = createModuleLog("Database");
 const Config = require("../classes/ConfigManager");
 
 class Database {

--- a/lib/classes/Lang.js
+++ b/lib/classes/Lang.js
@@ -1,4 +1,5 @@
-const { log, fileExtension, fileName } = require("./Utils.js");
+const { fileExtension, fileName, createModuleLog } = require("./Utils.js");
+const log = createModuleLog("Localization");
 const fs = require("fs").promises;
 const LanguagePack = require("./LanguagePack.js");
 

--- a/lib/classes/MessageParser.js
+++ b/lib/classes/MessageParser.js
@@ -3,7 +3,7 @@ const BaseCommand = require("../commands/BaseCommand.js");
 const BaseError = require("../classes/errors/BaseError.js");
 const CommandContext = require("./CommandContext.js");
 const Lang = require("./Lang.js");
-const { Guild } = require("./Database.js");
+const { Guild, GuildChannel, GuildMember, User, MessageStatistics } = require("./Database.js");
 
 /**
  * # Message Parser
@@ -18,24 +18,6 @@ class MessageParser {
 	message;
 
 	/**
-	 * Current prefix.
-	 * @type {string}
-	 */
-	prefix;
-
-	/**
-	 * Current command.
-	 * @type {string}
-	 */
-	command;
-
-	/**
-	 * Current parameters.
-	 * @type {Object}
-	 */
-	params;
-
-	/**
 	 * @param {Message} message Discord message.
 	 */
 	constructor(message) {
@@ -48,16 +30,10 @@ class MessageParser {
 	 *     available commands.
 	 */
 	async run() {
-		this.prefix = await Guild.resolvePrefix(this.message.guild.id);
-		const {
-			status,
-			commandName,
-			args
-		} = this.#parseContent({
-			message: this.message,
-			prefix: this.prefix
-		});
-		if (!status)
+		const { prefix } = await Guild.resolvePrefix(this.message.guild.id);
+		const { status, commandName, args } = this.#parseContent({ message: this.message, prefix });
+		await this.#pushStatistics(this.message);
+		if (status)
 			return;
 		const TargetCommand = CommandsRegistry.findCommand(commandName);
 		if (!(TargetCommand.prototype instanceof BaseCommand))
@@ -69,6 +45,7 @@ class MessageParser {
 			language: new Lang("en")
 		});
 		try {
+			/** @type {BaseCommand} */
 			const command = new TargetCommand(context);
 			await command.validate();
 			return await command.run();
@@ -78,11 +55,51 @@ class MessageParser {
 	}
 
 	/**
+	 * Creating tables entities at database for pushing statistics, pushing stats to text activity table.
+	 * @param {Message} message Discord JS message object.
+	 *
+	 * @todo Somehow check for tables elements existence to lower amount of queries sent to DB.
+	 * @this MessageParser
+	 */
+	#pushStatistics = async function (message) {
+		await User.findOrCreate({
+			where: { id: message.author.id }
+		});
+		const memberInstance = await GuildMember.findOrCreate({
+			where: {
+				id_guild: message.guild.id,
+				id_user: message.author.id
+			}
+		});
+		await GuildChannel.findOrCreate({
+			where: {
+				id: message.channel.id,
+				id_guild: message.guild.id
+			}
+		});
+		await MessageStatistics.create({
+			id_member: memberInstance[0].id,
+			weight: this.#calculateScore(message.content)
+		});
+	};
+
+	/**
+	 * Calculate statistics score from content.
+	 * @param {string} content Actual message content.
+	 * @return {number} Calculated score.
+	 * @this MessageParser
+	 */
+	#calculateScore = function (content) {
+		return this.constructor.wordRegex.exec(content).length;
+	};
+
+	/**
 	 * Parse current message content.
 	 * @param {Object} parseOptions Parsing options.
 	 * @param {Message} parseOptions.message Actual DiscordJS message.
 	 * @param {string} parseOptions.prefix Resolved for current guild prefix.
 	 * @return {ContentParsingResult} Result of content parsing. If nothing found then returns status only.
+	 * @this MessageParser
 	 */
 	#parseContent = function ({ message, prefix }) {
 		if (!message.content.startsWith(prefix))
@@ -105,6 +122,7 @@ class MessageParser {
 	 * @param {CommandContext} context Command context for showing error for current command execution.
 	 * @return {void | DefaultEmbed} Object of DefaultEmbed class to show this error or nothing if embed generating is
 	 * not possible.
+	 * @this MessageParser
 	 */
 	#handleError = function (error, context) {
 		if (error instanceof BaseError)
@@ -113,6 +131,12 @@ class MessageParser {
 		const unexpectedError = new BaseError("Unexpected error occurred!");
 		return unexpectedError.toEmbed({ context });
 	};
+
+	/**
+	 * RegExp for calculating score from message content.
+	 * @type {RegExp}
+	 */
+	static wordRegex = /[^\s!?.:,@<>/\\_]{3,}/g;
 }
 
 /**

--- a/lib/classes/MessageParser.js
+++ b/lib/classes/MessageParser.js
@@ -80,6 +80,7 @@ class MessageParser {
 		await MessageStatistics.create({
 			id: message.id,
 			id_member: memberInstance[0].id,
+			id_channel: message.channel.id,
 			weight: this.#calculateScore(message.content)
 		});
 	};

--- a/lib/classes/MessageParser.js
+++ b/lib/classes/MessageParser.js
@@ -33,7 +33,7 @@ class MessageParser {
 		const { prefix } = await Guild.resolvePrefix(this.message.guild.id);
 		const { status, commandName, args } = this.#parseContent({ message: this.message, prefix });
 		await this.#pushStatistics(this.message);
-		if (status)
+		if (!status)
 			return;
 		const TargetCommand = CommandsRegistry.findCommand(commandName);
 		if (!(TargetCommand.prototype instanceof BaseCommand))
@@ -78,6 +78,7 @@ class MessageParser {
 			}
 		});
 		await MessageStatistics.create({
+			id: message.id,
 			id_member: memberInstance[0].id,
 			weight: this.#calculateScore(message.content)
 		});
@@ -90,7 +91,7 @@ class MessageParser {
 	 * @this MessageParser
 	 */
 	#calculateScore = function (content) {
-		return this.constructor.wordRegex.exec(content).length;
+		return this.constructor.wordRegex.exec(content)?.length ?? 0;
 	};
 
 	/**

--- a/lib/classes/MessageParser.js
+++ b/lib/classes/MessageParser.js
@@ -138,7 +138,7 @@ class MessageParser {
 	 * RegExp for calculating score from message content.
 	 * @type {RegExp}
 	 */
-	static wordRegex = /[^\s!?.:,@<>/\\_]{3,}/g;
+	static wordRegex = /[^\s\d!?.:,@<>/\\_]{3,}/g;
 }
 
 /**

--- a/lib/classes/MessageParser.js
+++ b/lib/classes/MessageParser.js
@@ -4,6 +4,8 @@ const BaseError = require("../classes/errors/BaseError.js");
 const CommandContext = require("./CommandContext.js");
 const Lang = require("./Lang.js");
 const { Guild, GuildChannel, GuildMember, User, MessageStatistics } = require("./Database.js");
+const { createModuleLog } = require("./Utils.js");
+const log = createModuleLog("MessageParser");
 
 /**
  * # Message Parser
@@ -32,7 +34,12 @@ class MessageParser {
 	async run() {
 		const { prefix } = await Guild.resolvePrefix(this.message.guild.id);
 		const { status, commandName, args } = this.#parseContent({ message: this.message, prefix });
-		await this.#pushStatistics(this.message);
+		try {
+			await this.#pushStatistics(this.message);
+		} catch (error) {
+			log("error", `Failed to push statistics! Message ID: ${this.message.id}.`);
+			console.dir(error);
+		}
 		if (!status)
 			return;
 		const TargetCommand = CommandsRegistry.findCommand(commandName);

--- a/lib/classes/MessageParser.js
+++ b/lib/classes/MessageParser.js
@@ -92,7 +92,7 @@ class MessageParser {
 	 * @this MessageParser
 	 */
 	#calculateScore = function (content) {
-		return this.constructor.wordRegex.exec(content)?.length ?? 0;
+		return content.match(this.constructor.wordRegex)?.length ?? 0;
 	};
 
 	/**

--- a/lib/classes/Utils.js
+++ b/lib/classes/Utils.js
@@ -1,10 +1,7 @@
-// const path = require("path");
-
 /**
- * @typedef {"log"|"error"|"warn"|"info"|"success"} LogType Available types of log. This types will be used in future
- *     for better styling of logging and enabling different logs channels to show in console prompt.
+ * # Utilities
+ * Object with useful utilities may be used in the code.
  */
-
 const Utils = {
 	/**
 	 * Centralized logging function. Used for unified style of logging.

--- a/lib/classes/Utils.js
+++ b/lib/classes/Utils.js
@@ -5,7 +5,7 @@
  *     for better styling of logging and enabling different logs channels to show in console prompt.
  */
 
-module.exports = {
+const Utils = {
 	/**
 	 * Centralized logging function. Used for unified style of logging.
 	 * @param {LogType} type Type of log.
@@ -17,6 +17,24 @@ module.exports = {
 	log(type, message) {
 		const now = new Date();
 		console.log(`${now.toLocaleString()} [${type}] ${message}`);
+	},
+
+	/**
+	 * Logging function factory. Uses closures for inserting module name into the original log function.
+	 * @param {string} moduleName Name of the module.
+	 * @return {function(type: LogType, message: string)} A modified log function with module name. Similar to
+	 *     {@link Utils.log} function.
+	 * @example
+	 * // Creating a modified log function for module.
+	 * const log = createModuleLog('SystemModule');
+	 *
+	 * log('log', 'Loading system module...');
+	 * // 8/7/2020, 12:20:36 AM [SystemModule] [log] Loading system module...
+	 */
+	createModuleLog(moduleName) {
+		return (type, message) => {
+			Utils.log(moduleName, `[${type}] ${message}`);
+		};
 	},
 
 	/**
@@ -101,3 +119,5 @@ module.exports = {
 		return `\`${escaped}\``;
 	}
 };
+
+module.exports = Utils;

--- a/lib/database/migrations/20200806213122-add-channel-relationship-to-message-table.js
+++ b/lib/database/migrations/20200806213122-add-channel-relationship-to-message-table.js
@@ -1,0 +1,41 @@
+"use strict";
+
+module.exports = {
+	/**
+	 * Adding new field to table.
+	 * Be careful! This migration will clear all message statistics data!
+	 * @param {import(sequelize).QueryInterface} queryInterface
+	 * @param {import(sequelize)} Sequelize
+	 * @return {Promise<void>}
+	 */
+	up: async (queryInterface, Sequelize) => {
+		// New column requires relationship with one of the channels, but there is no information about channels
+		// available, so we can't use old data after this migration. Deleting all available data.
+		await queryInterface.bulkDelete("message", {});
+		await queryInterface.addColumn("message", "id_channel", {
+			type: Sequelize.BIGINT.UNSIGNED,
+			allowNull: false,
+			comment: "Related channel ID"
+		});
+		await queryInterface.addConstraint("message", {
+			fields: ["id_channel"],
+			type: "foreign key",
+			name: "fk_message_related_to_guild_channel",
+			references: {
+				table: "channel",
+				field: "id"
+			},
+			onDelete: "restrict",
+			onUpdate: "restrict"
+		});
+	},
+	/**
+	 * Reverting this added field. All data will be saved.
+	 * @param {import(sequelize).QueryInterface} queryInterface
+	 * @return {Promise<void>}
+	 */
+	down: async (queryInterface) => {
+		await queryInterface.removeConstraint("message", "fk_message_related_to_guild_channel");
+		await queryInterface.removeColumn("message", "id_channel");
+	}
+};

--- a/lib/database/models/BaseModel.js
+++ b/lib/database/models/BaseModel.js
@@ -1,6 +1,7 @@
 const _ = require("lodash");
 const { Model } = require("sequelize");
-const { log } = require("../../classes/Utils.js");
+const { createModuleLog } = require("../../classes/Utils.js");
+const log = createModuleLog("Database");
 
 class BaseModel extends Model {
 	static attributes;

--- a/lib/database/models/Guild.js
+++ b/lib/database/models/Guild.js
@@ -111,6 +111,11 @@ class Guild extends BaseModel {
 		tableName: "guild"
 	};
 
+	/**
+	 * Resolving Guild instance and returns prefix if set.
+	 * @param {string} guildId Discord Guild ID.
+	 * @return {Promise<{guildInstance: Guild, prefix: string}>} Guild instance and prefix resolved using Config class.
+	 */
 	static async resolvePrefix(guildId) {
 		let prefix = Config.get("preferences.cognitum.prefix");
 		const guild = await Guild.findOrCreate({
@@ -120,7 +125,10 @@ class Guild extends BaseModel {
 		});
 		if (guild[0].get("prefix") !== null)
 			prefix = guild[0].get("prefix");
-		return prefix;
+		return {
+			prefix,
+			guildInstance: guild[0]
+		};
 	}
 }
 

--- a/lib/database/models/MessageStatistics.js
+++ b/lib/database/models/MessageStatistics.js
@@ -1,4 +1,5 @@
 const GuildMember = require("./GuildMember.js");
+const GuildChannel = require("./GuildChannel.js");
 const BaseModel = require("./BaseModel.js");
 const Sequelize = require("sequelize");
 
@@ -14,6 +15,14 @@ class MessageStatistics extends BaseModel {
 			allowNull: false,
 			references: {
 				model: GuildMember,
+				key: "id"
+			}
+		},
+		id_channel: {
+			type: Sequelize.BIGINT.UNSIGNED,
+			allowNull: false,
+			references: {
+				model: GuildChannel,
 				key: "id"
 			}
 		},

--- a/lib/types/LogType.js
+++ b/lib/types/LogType.js
@@ -1,0 +1,4 @@
+/**
+ * @typedef {"log"|"error"|"warn"|"info"|"success"} LogType Available types of log. This types will be used in future
+ *     for better styling of logging and enabling different logs channels to show in console prompt.
+ */


### PR DESCRIPTION
This is first of the important PRs for this bot: implementation of actual statistics feature.

## Changes:

+ Updating `message` table and `MessageStatistics` model with `id_channel` fields. **Attention!** This migration requires total wipe out of message statistics data. It's not that important right now just because bot is not released yet but any similar changes must be marked in the future;
+ Pushing messages statistics data on every message before actual message parsing and command calling called;
+ Score calculated by matching string with special RegExp in `MessageParser.wordRegex` static property.
+ `Guild.resolvePrefix` now returns prefix and `Guild` model instance in the object.
+ `Utils.createModuleLog` function for generating module-related log functions. Example can be found below.
+ Using `Utils.createModuleLog` on every initialized module.

## `Utils.createModuleLog` usage example

```js
// Creating a modified log function for module.
const log = createModuleLog('SystemModule');

log('log', 'Loading system module...');
// 8/7/2020, 12:20:36 AM [SystemModule] [log] Loading system module...
```

## Updated `Guild.resolvePrefix` usage

```js
const { prefix, guildInstance } = await Guild.resolvePrefix("GUILD_ID_HERE");
// if guildInstance is not required, just skip it
const { prefix } = await Guild.resolvePrefix("GUILD_ID_HERE");
```