### PR TITLE
Fix obsolete channel types names

### DIFF
--- a/lib/classes/LogsProcessor.js
+++ b/lib/classes/LogsProcessor.js
@@ -211,7 +211,7 @@ class LogsProcessor extends BaseDiscordModule {
 
 		const logMessage = this.constructor.#eventMessageRenderer[eventName]?.(...args);
 
-		if (channel.type !== "text")
+		if (channel.type !== "GUILD_TEXT")
 			return;
 
 		try {

--- a/lib/classes/nicknames/NicknamesProcessor.js
+++ b/lib/classes/nicknames/NicknamesProcessor.js
@@ -43,7 +43,7 @@ class NicknamesProcessor extends BaseDiscordModule {
 	async #handleMessage(message) {
 		if (
 			message.author.bot
-			|| message.channel.type !== "text"
+			|| message.channel.type !== "GUILD_TEXT"
 			|| message.member.permissions.has("ADMINISTRATOR")
 			|| message.member.permissions.has("MANAGE_NICKNAMES")
 		) {

--- a/lib/commands/guild/LogSettingsCommand.js
+++ b/lib/commands/guild/LogSettingsCommand.js
@@ -163,7 +163,7 @@ class LogSettingsCommand extends BaseCommand {
 			if (channelID === null)
 				throw new Error("Incorrect channel ID passed! This argument must contains Channel ID!");
 			targetChannel = this.message.guild?.channels.cache.find(channel => channel.id === channelID);
-			if (!targetChannel || targetChannel.type !== "text" || !targetChannel.viewable)
+			if (!targetChannel || targetChannel.type !== "GUILD_TEXT" || !targetChannel.viewable)
 				throw new Error("This channel is not exist or it is not viewable by bot!");
 		}
 
@@ -186,7 +186,7 @@ class LogSettingsCommand extends BaseCommand {
 			)
 			.setDescription(
 				this.resolveLang(
-					`command.log.channel.${type}.${targetChannel?.type === "text" ? "set" : "reset"}`,
+					`command.log.channel.${type}.${targetChannel?.type === "GUILD_TEXT" ? "set" : "reset"}`,
 					{
 						channelName: targetChannel?.name,
 						channelId: targetChannel?.id

--- a/lib/commands/guild/WelcomeCommand.js
+++ b/lib/commands/guild/WelcomeCommand.js
@@ -61,7 +61,7 @@ class WelcomeCommand extends BaseCommand {
 	 */
 	async setWelcomeChannel(id) {
 		const targetChannel = this.message.guild.channels.cache.find(
-			channel => channel.id === id && channel.type === "text"
+			channel => channel.id === id && channel.type === "GUILD_TEXT"
 		);
 		if (!targetChannel)
 			throw new Error("Target channel not found!");

--- a/lib/commands/stats/TopCommand.js
+++ b/lib/commands/stats/TopCommand.js
@@ -22,7 +22,7 @@ class TopCommand extends BaseCommand {
 			return await this.#generateVoiceList();
 		if (["users", "u"].includes(this.args[0]))
 			return await this.#generateMembersList();
-		if (this.message.mentions.channels.size && this.message.mentions.channels.first()?.type === "text")
+		if (this.message.mentions.channels.size && this.message.mentions.channels.first()?.type === "GUILD_TEXT")
 			return await this.#generateMembersListForChannel(this.message.mentions.channels.first());
 		throw new ArgumentError("value", {
 			argumentPassed: this.args[0]


### PR DESCRIPTION
Channel types string was obsolete. After updating to Discord.JS v13 any channel types checks was failing.