### PR TITLE
Gathering statistics of activity from threads as activity of their parent channels

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -11,7 +11,10 @@
   "rules": {
     "indent": [
       "error",
-      "tab"
+      "tab",
+      {
+        "SwitchCase": 1
+      }
     ],
     "linebreak-style": [
       "error",

--- a/lib/classes/MessageProcessor.js
+++ b/lib/classes/MessageProcessor.js
@@ -26,19 +26,25 @@ class MessageProcessor extends BaseDiscordModule {
 			author
 		} = message;
 
-		// Ignoring news and direct channels from parsing
-		if (channel.type !== ChannelType.GuildText)
-			return void ("Not implemented yet!");
-
 		// Ignoring any bots messages from parsing
 		if (author.bot)
 			return;
 
-		// Handling bot mention-only messages
-		if (await this.#isMentionOnly(message))
-			return await this.#onMessageWithMentionOnly(message);
+		switch (channel.type) {
+			case ChannelType.GuildText:
+				// Handling bot mention-only messages
+				if (await this.#isMentionOnly(message))
+					return await this.#onMessageWithMentionOnly(message);
 
-		await this.#onGuildMessage(message);
+				await this.#onGuildMessage(message);
+				break;
+
+			// Processing threads
+			case ChannelType.PublicThread:
+			case ChannelType.PrivateThread:
+				await this.#onThreadMessage(message);
+				break;
+		}
 	}
 
 	/**
@@ -77,6 +83,16 @@ class MessageProcessor extends BaseDiscordModule {
 			console.warn(e);
 			return await channel.send({ content: ":warning: Unresolved command result handling error!" });
 		}
+	}
+
+	/**
+	 * Handle incoming message from one of the guild threads. This message will be only processed for statistics
+	 * generation. No commands will be executed.
+	 * @param message
+	 * @returns {Promise<void>}
+	 */
+	async #onThreadMessage(message) {
+		await MessageParser.calculateAndStoreStatistics(message);
 	}
 
 	/**

--- a/lib/classes/commands/MessageParser.js
+++ b/lib/classes/commands/MessageParser.js
@@ -193,7 +193,7 @@ class MessageParser {
 	}
 
 	/**
-	 *
+	 * Calculate and store statistics for current message. Channel type will be checked inside.
 	 * @param {import('discord.js').Message} message Target message object.
 	 * @param {ContextModelsInstances|null} databaseInstances (Optional) Already resolved database instances. If not
 	 * present, database instances will be requested from the database.

--- a/lib/classes/commands/MessageParser.js
+++ b/lib/classes/commands/MessageParser.js
@@ -7,6 +7,7 @@ const { GuildModel, GuildChannelModel, GuildMemberModel, UserModel, MessageStati
 const { createModuleLogger } = require("../Utils");
 const logger = createModuleLogger("MessageParser");
 const ConfigManager = require("../ConfigManager");
+const { ChannelType } = require("discord-api-types/v10");
 
 /**
  * # Message Parser
@@ -72,23 +73,7 @@ class MessageParser {
 	async #resolveInstancesWithStats() {
 		const databaseInstances = await this.#resolveInstances();
 
-		// Only process message statistics if user is trackable.
-		if (!databaseInstances.user["trackable"]) {
-			return databaseInstances;
-		}
-
-		// Add message statistics to database.
-		try {
-			await MessageStatisticsModel.create({
-				id: this.message.id,
-				id_member: databaseInstances.member.id,
-				id_channel: this.message.channel.id,
-				weight: this.#calculateScore(this.message.content)
-			});
-		} catch (error) {
-			logger.error(`Failed to push statistics! Message ID: ${this.message.id}.`);
-			console.dir(error);
-		}
+		await MessageParser.calculateAndStoreStatistics(this.message, databaseInstances);
 
 		return databaseInstances;
 	};
@@ -98,7 +83,7 @@ class MessageParser {
 	 * @return {Promise<ContextModelsInstances>}
 	 */
 	async #resolveInstances() {
-		return MessageParser.resolveDatabaseInstances(this.message);
+		return MessageParser.#resolveDatabaseInstances(this.message);
 	};
 
 	/**
@@ -106,7 +91,7 @@ class MessageParser {
 	 * @param {string} content Actual message content.
 	 * @return {number} Calculated score.
 	 */
-	#calculateScore(content) {
+	static #calculateScore(content) {
 		return content.match(MessageParser.wordRegex)?.length ?? 0;
 	};
 
@@ -167,29 +152,90 @@ class MessageParser {
 	/**
 	 * Resolve all required database instances from target message.
 	 * @param {import("discord.js").Message} message Target message.
+	 * @param {Partial<{channel: string, guild: string, user: string }>|null} ids (Optional) List of the ID overrides.
 	 * @return {Promise<ContextModelsInstances>} List of instances required for work.
 	 */
-	static async resolveDatabaseInstances(message) {
+	static async #resolveDatabaseInstances(message, ids = null) {
+		let {
+			channel: { id: channelId },
+			guild: { id: guildId },
+			author: { id: userId }
+		} = message;
+
+		ids ??= {};
+		ids.guild ??= guildId;
+		ids.channel ??= channelId;
+		ids.user ??= userId;
+
 		const [guild] = await GuildModel.findOrCreate({
-			where: { id: message.guild.id }
+			where: { id: ids.guild }
 		});
+
 		const [user] = await UserModel.findOrCreate({
-			where: { id: message.author.id }
+			where: { id: ids.user }
 		});
+
 		const [member] = await GuildMemberModel.findOrCreate({
 			where: {
-				id_guild: message.guild.id,
-				id_user: message.author.id
+				id_guild: ids.guild,
+				id_user: ids.user
 			}
 		});
+
 		const [channel] = await GuildChannelModel.findOrCreate({
 			where: {
-				id: message.channel.id,
-				id_guild: message.guild.id
+				id: ids.channel,
+				id_guild: ids.guild
 			}
 		});
 
 		return { guild, user, member, channel };
+	}
+
+	/**
+	 *
+	 * @param {import('discord.js').Message} message Target message object.
+	 * @param {ContextModelsInstances|null} databaseInstances (Optional) Already resolved database instances. If not
+	 * present, database instances will be requested from the database.
+	 * @returns {Promise<void>}
+	 */
+	static async calculateAndStoreStatistics(message, databaseInstances = null) {
+		const { /** @type {import('discord.js').GuildChannel} */ channel } = message;
+		let targetChannelId = channel.id;
+
+		// For threads, use parent channel ID.
+		if (channel.type === ChannelType.PublicThread || channel.type === ChannelType.PrivateThread) {
+			targetChannelId = channel.parentId;
+
+			// If parent channel is found and there are database instances present, we should not track anything to prevent
+			// possible database errors.
+			if (databaseInstances) {
+				console.error("Database instances should not be passed when calculating statistics for threads! This might cause incorrect statistics!");
+				return;
+			}
+		}
+
+		// If database instances are not provided, resolve them.
+		if (databaseInstances === null)
+			databaseInstances = await MessageParser.#resolveDatabaseInstances(message, { channel: targetChannelId });
+
+		// Only process message statistics if user is trackable.
+		if (!databaseInstances.user["trackable"]) {
+			return;
+		}
+
+		// Add message statistics to database.
+		try {
+			await MessageStatisticsModel.create({
+				id: message.id,
+				id_member: databaseInstances.member.id,
+				id_channel: targetChannelId,
+				weight: this.#calculateScore(message.content)
+			});
+		} catch (error) {
+			logger.error(`Failed to push statistics! Message ID: ${message.id}.`);
+			console.dir(error);
+		}
 	}
 }
 


### PR DESCRIPTION
Implements task #136. But even if we collect statistics for those channels, we do not process any commands inside of them. This might change in the future.