### PR TITLE
Cover unhandled exception with try-catch

### DIFF
--- a/lib/classes/MessageProcessor.js
+++ b/lib/classes/MessageProcessor.js
@@ -81,7 +81,8 @@ class MessageProcessor extends BaseDiscordModule {
 		} catch (e) {
 			logger.warn("Failed to send command execution result!");
 			console.warn(e);
-			return await channel.send({ content: ":warning: Unresolved command result handling error!" });
+
+			await this.#trySendUnhandledErrorMessage(channel, ":warning: Unresolved command result handling error!");
 		}
 	}
 
@@ -115,7 +116,24 @@ class MessageProcessor extends BaseDiscordModule {
 		} catch (e) {
 			logger.warn("Failed to send command execution result!");
 			console.warn(e);
-			return channel.send({ content: ":warning: Unresolved command result handling error!" });
+
+			await this.#trySendUnhandledErrorMessage(channel, ":warning: Unresolved command result handling error!");
+		}
+	}
+
+	/**
+	 * Last resort method for sending error message. If this method fails, then there is no way to send error message to
+	 * the selected channel. We just give up.
+	 * @param {import('discord.js').GuildChannel} targetChannel Channel where the error message should appear.
+	 * @param {string} content Text for the error message.
+	 * @return {Promise<void>}
+	 */
+	static async #trySendUnhandledErrorMessage(targetChannel, content) {
+		try {
+			await targetChannel.send({ content });
+		} catch (e) {
+			// Ignoring any following errors. If owner of the guild blocked bot from sending messages, just do nothing.
+			// It's their problem.
 		}
 	}
 


### PR DESCRIPTION
- Closes #150 

Note: If owner of the guild didn't give required permissions to the bot — it's guild owner's problem.